### PR TITLE
fix: update set output (fix deprecated)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,10 +36,10 @@ runs:
         if grep -q "204" http.txt;
         then
           echo "Todo OK"
-          echo "::set-output name=OUTPUT::0"
+          echo "OUTPUT=0" >> $GITHUB_OUTPUT 
         else 
           echo "la branch no se seteo por defecto se eliminara la branch para definir la nueva por defecto"
-          echo "::set-output name=OUTPUT::1"
+          echo "OUTPUT=1" >> $GITHUB_OUTPUT 
         fi
       shell: bash
     - name: "Delete and Rename branch"


### PR DESCRIPTION
# Fix:
- Actualizar manera de generar outputs en las acciones, para corregir el mensaje de deprecado.

[Documentación](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)